### PR TITLE
Sign-then-encrypt functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,7 @@ smallvec = "*"
 base64 = "*"
 hex = "*"
 thiserror = "*"
-p256 = { version = "*", features = ["pem", "alloc"] }
+p256 = { version = "*", features = ["pem", "alloc", "ecdsa", "ecdh"] }
+pem = "*"
+ecies = {version = "*", features = ["std"]}
+libsecp256k1 = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ smallvec = "*"
 base64 = "*"
 hex = "*"
 thiserror = "*"
+p256 = { version = "*", features = ["pem", "alloc"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,4 +16,5 @@
  */
 
 pub mod secret_sharing;
-pub mod channel;
+//pub mod channel;
+pub mod secure_channel;

--- a/src/secure_channel/encrypt.rs
+++ b/src/secure_channel/encrypt.rs
@@ -1,0 +1,70 @@
+use rand_chacha::rand_core::OsRng; // requires 'getrandom' feature
+use pem::{Pem, parse, encode};
+use libsecp256k1::{PublicKey, SecretKey};
+
+// outputs the pair (pub key, priv key), both in PEM format
+pub fn generate_encryption_key() -> (Vec<u8>, Vec<u8>) {
+    let sk = SecretKey::random(&mut OsRng);
+    let pk = PublicKey::from_secret_key(&sk);
+
+    //let (sk, pk) = (&sk.serialize(), &pk.serialize());
+
+    let sk_pem = Pem::new(
+        "PRIVATE KEY",
+        sk.serialize().to_vec()
+    );
+
+    let pk_pem = Pem::new(
+        "PUBLIC KEY", 
+        pk.serialize().to_vec()
+    );
+
+    (
+        encode(&pk_pem).as_bytes().to_vec(),
+        encode(&sk_pem).as_bytes().to_vec()
+    )
+}
+
+// outputs the signature as a byte array
+pub fn encrypt(message: &[u8], public_key: &[u8]) -> Vec<u8> {
+
+    let pk_pem = parse(
+        String::from_utf8(
+            public_key.to_vec()
+        ).unwrap()
+    ).unwrap();
+
+    let pk = pk_pem.contents();
+
+    ecies::encrypt(pk, message).unwrap()
+}
+
+pub fn decrypt(ciphertext: &[u8], secret_key: &[u8]) -> Vec<u8> {
+    let sk_pem = parse(
+        String::from_utf8(
+            secret_key.to_vec()
+        ).unwrap()
+    ).unwrap();
+
+    let sk = sk_pem.contents();
+    ecies::decrypt(sk, ciphertext).unwrap()
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encryption() {
+        // Generate secret key
+        let (pk, sk) = generate_encryption_key();
+        // println!("pk: {:?}", String::from_utf8(pk.to_vec()).unwrap());
+        // println!("sk: {:?}", String::from_utf8(sk.to_vec()).unwrap());
+        
+        let msg = b"hello world";
+        let ctxt = encrypt(msg, &pk);
+
+        assert_eq!(msg, decrypt(&ctxt, &sk).as_slice());
+    }
+}

--- a/src/secure_channel/mod.rs
+++ b/src/secure_channel/mod.rs
@@ -1,0 +1,1 @@
+pub mod sign;

--- a/src/secure_channel/mod.rs
+++ b/src/secure_channel/mod.rs
@@ -1,2 +1,68 @@
 pub mod sign;
 pub mod encrypt;
+
+pub fn sign_then_encrypt(
+    message: &[u8],
+    signing_key: &[u8],
+    public_key: &[u8]
+) -> Vec<u8> {
+    let signature = sign::sign(message, signing_key);
+
+    // let us assemble the cleartext as signature followed by the message
+    let mut cleartext = vec![];
+    cleartext.extend_from_slice(&signature);
+    cleartext.extend_from_slice(message);
+
+    encrypt::encrypt(&cleartext, public_key)
+}
+
+pub fn decrypt_then_verify(
+    ciphertext: &[u8],
+    verification_key: &[u8],
+    secret_key: &[u8]
+) -> Option<Vec<u8>> {
+    let cleartext = encrypt::decrypt(ciphertext, secret_key);
+
+    // signature is first 64 bytes
+    let signature = &cleartext[..64];
+    // rest is the message bytes
+    let message = &cleartext[64..];
+
+    if sign::verify(&message, &signature, verification_key) {
+        Some(message.to_vec())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sign_then_encrypt() {
+        let (alice_signing_vk, alice_signing_sk) =
+            sign::generate_signing_key();
+        let (alice_encryption_pk, alice_encryption_sk) =
+            encrypt::generate_encryption_key();
+
+        let (bob_signing_vk, bob_signing_sk) =
+            sign::generate_signing_key();
+        let (bob_encryption_pk, bob_encryption_sk) =
+            encrypt::generate_encryption_key();
+
+        let msg = b"hello from alice";
+
+        // let alice sign-then-encrypt the message for bob
+        let ctxt = super::sign_then_encrypt(
+            msg, &alice_signing_sk, &bob_encryption_pk
+        );
+
+        // let bob decrypt-then-verify the message from alice
+        let received = super::decrypt_then_verify(
+            &ctxt, &alice_signing_vk, &bob_encryption_sk
+        );
+
+        assert_eq!(received.unwrap(), msg);
+    }
+}

--- a/src/secure_channel/mod.rs
+++ b/src/secure_channel/mod.rs
@@ -1,1 +1,2 @@
 pub mod sign;
+pub mod encrypt;

--- a/src/secure_channel/sign.rs
+++ b/src/secure_channel/sign.rs
@@ -1,0 +1,76 @@
+use p256::{
+    ecdsa::{
+        signature::{Signer, Verifier},
+        Signature, SigningKey, VerifyingKey,
+    },
+    pkcs8::EncodePrivateKey,
+    PublicKey, SecretKey,
+};
+use rand_chacha::rand_core::OsRng;
+
+// outputs the pair (pub key, priv key)
+pub fn generate_signing_key() -> (Vec<u8>, Vec<u8>) {
+    // Generate secret key
+    let secret_key = SecretKey::random(&mut OsRng);
+
+    let secret_key_serialized = secret_key
+        .to_pkcs8_pem(Default::default())
+        .unwrap()
+        .to_string();
+
+    // Derive public key
+    let public_key = secret_key.public_key();
+
+    // Store public key
+    let public_key_serialized = public_key.to_string();
+    
+    (
+        public_key_serialized.as_bytes().to_vec(), 
+        secret_key_serialized.as_bytes().to_vec()
+    )
+}
+
+// outputs the signature as a byte array
+pub fn sign_message(message: &[u8], secret_key: &[u8]) -> Vec<u8> {
+    // Load secret key
+    let secret_key = String::from_utf8(secret_key.to_vec())
+        .unwrap()
+        .parse::<SecretKey>()
+        .unwrap();
+
+    // convert secret key to signing key
+    let signing_key: SigningKey = secret_key.into();
+
+    let signature: Signature = signing_key.sign(message);
+
+    signature.to_vec()
+}
+
+pub fn verify_signature(message: &[u8], signature: &[u8], public_key: &[u8]) -> bool {
+    // Load public key
+    let public_key = String::from_utf8(public_key.to_vec())
+        .unwrap()
+        .parse::<PublicKey>()
+        .unwrap();
+
+    // convert public key to verifying key
+    let verifying_key: VerifyingKey = public_key.into();
+
+    let signature = Signature::try_from(&signature[..]).unwrap();
+
+    verifying_key.verify(message, &signature).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;    
+
+    #[test]
+    fn test_signing() {
+        // Generate secret key
+        let (pk, sk) = generate_signing_key();
+        let msg = b"hello world";
+        let signature = sign_message(msg, &sk);
+        assert!(verify_signature(msg, &signature, &pk));
+    }
+}

--- a/src/secure_channel/sign.rs
+++ b/src/secure_channel/sign.rs
@@ -8,31 +8,36 @@ use p256::{
 };
 use rand_chacha::rand_core::OsRng;
 
-// outputs the pair (pub key, priv key)
+// outputs the pair (pub key, secret key), 
+// both in PEM encoding (as a utf-8 byte array)
 pub fn generate_signing_key() -> (Vec<u8>, Vec<u8>) {
     // Generate secret key
     let secret_key = SecretKey::random(&mut OsRng);
 
+    // serialize secret key in PEM format
     let secret_key_serialized = secret_key
         .to_pkcs8_pem(Default::default())
         .unwrap()
         .to_string();
 
-    // Derive public key
+    // Derive public key from secret key
     let public_key = secret_key.public_key();
 
-    // Store public key
+    // serializing public key in PEM format
     let public_key_serialized = public_key.to_string();
     
+    // output the pair (pub key, secret key)
     (
         public_key_serialized.as_bytes().to_vec(), 
         secret_key_serialized.as_bytes().to_vec()
     )
 }
 
-// outputs the signature as a byte array
-pub fn sign_message(message: &[u8], secret_key: &[u8]) -> Vec<u8> {
-    // Load secret key
+// outputs the signature as a byte array, given a message and a secret key
+// secret_key is PEM string (as a utf-8 byte array) output by generate_signing_key
+pub fn sign(message: &[u8], secret_key: &[u8]) -> Vec<u8> {
+
+    // parse secret key from PEM format
     let secret_key = String::from_utf8(secret_key.to_vec())
         .unwrap()
         .parse::<SecretKey>()
@@ -41,12 +46,14 @@ pub fn sign_message(message: &[u8], secret_key: &[u8]) -> Vec<u8> {
     // convert secret key to signing key
     let signing_key: SigningKey = secret_key.into();
 
+    // let us sign
     let signature: Signature = signing_key.sign(message);
-
     signature.to_vec()
 }
 
-pub fn verify_signature(message: &[u8], signature: &[u8], public_key: &[u8]) -> bool {
+// verifies a signature given a message, signature, and public key
+// public_key is PEM string (as a utf-8 byte array) output by generate_signing_key
+pub fn verify(message: &[u8], signature: &[u8], public_key: &[u8]) -> bool {
     // Load public key
     let public_key = String::from_utf8(public_key.to_vec())
         .unwrap()
@@ -56,8 +63,10 @@ pub fn verify_signature(message: &[u8], signature: &[u8], public_key: &[u8]) -> 
     // convert public key to verifying key
     let verifying_key: VerifyingKey = public_key.into();
 
+    // parse signature in byte array
     let signature = Signature::try_from(&signature[..]).unwrap();
 
+    // output boolean indicating whether signature is valid
     verifying_key.verify(message, &signature).is_ok()
 }
 
@@ -69,8 +78,10 @@ mod tests {
     fn test_signing() {
         // Generate secret key
         let (pk, sk) = generate_signing_key();
+        println!("pk: {:?}", String::from_utf8(pk.to_vec()).unwrap());
+        println!("sk: {:?}", String::from_utf8(sk.to_vec()).unwrap());
         let msg = b"hello world";
-        let signature = sign_message(msg, &sk);
-        assert!(verify_signature(msg, &signature, &pk));
+        let signature = sign(msg, &sk);
+        assert!(verify(msg, &signature, &pk));
     }
 }


### PR DESCRIPTION
Adds a sign-then-encrypt method, in addition to the underlying signing and encryption methods (which are used in pairing). The implementation uses the ECIES scheme for encryption, and ECDSA for signatures -- both using secp256 curve.
