### PR TITLE
replacing the use of secp256r1 with secp256k1 in ecdsa

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ smallvec = "*"
 base64 = "*"
 hex = "*"
 thiserror = "*"
-p256 = { version = "*", features = ["pem", "alloc", "ecdsa", "ecdh"] }
 pem = "*"
 ecies = {version = "*", features = ["std"]}
 libsecp256k1 = "*"


### PR DESCRIPTION
The secp256k1 curve is desirable compared to secp256r1.