### PR TITLE
Gradle cleanup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "jni/src/proto/protobufs"]
-	path = jni/src/proto/protobufs
-	url = https://github.com/derecalliance/protobufs
 [submodule "jni/derec_crypto_bridge_lib/src/proto/protobufs"]
 	path = jni/derec_crypto_bridge_lib/src/proto/protobufs
 	url = https://github.com/derecalliance/protobufs

--- a/example-app/Makefile
+++ b/example-app/Makefile
@@ -1,0 +1,16 @@
+all: deps run
+
+deps:
+	mkdir -p native_libs libs
+	cp ../jni/build/libs/derec-crypto-bridge-1.0-SNAPSHOT.jar libs/derec-crypto-bridge.jar
+	cp ../jni/derec_crypto_bridge_lib/target/debug/libderec_crypto_bridge_lib.dylib native_libs/
+	
+
+run:
+	mvn clean compile
+	export MAVEN_OPTS=-Djava.library.path=$(pwd)/native_libs
+	mvn exec:java -Dexec.mainClass=com.example.App -Dexec.classpathScope=compile
+
+clean:
+	mvn clean
+	rm -rf libs native_libs

--- a/example-app/pom.xml
+++ b/example-app/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>my-app</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>my-app</name>
+  <url>http://maven.apache.org</url>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <native.lib.path>${project.basedir}/native_libs/</native.lib.path>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.derecalliance.derec.crypto</groupId>
+      <artifactId>derec-crypto-bridge</artifactId>
+      <version>1.0</version>
+      <scope>system</scope>
+      <systemPath>${project.basedir}/libs/derec-crypto-bridge.jar</systemPath>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>3.8.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <configuration>
+              <mainClass>com.example.App</mainClass>
+              <arguments>
+                <argument>-Djava.library.path=${native.lib.path}</argument>
+              </arguments>
+              <includeProjectDependencies>true</includeProjectDependencies>
+              <includePluginDependencies>true</includePluginDependencies>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/example-app/src/main/java/com/example/App.java
+++ b/example-app/src/main/java/com/example/App.java
@@ -1,0 +1,51 @@
+package com.example;
+
+import org.derecalliance.derec.crypto.DerecCryptoImpl;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * Hello world!
+ *
+ */
+public class App 
+{
+    public static void main( String[] args )
+    {
+        DerecCryptoImpl cryptoImpl = new DerecCryptoImpl();
+
+        byte[] id = "some_id".getBytes();
+        byte[] secret = "top_secret".getBytes();
+
+        List<byte[]> shares = cryptoImpl.share(id, 0, secret, 5, 3);
+        byte[] recovered = cryptoImpl.recover(id, 0, shares);
+
+        String recovered_value = new String(recovered, StandardCharsets.UTF_8);
+        assert(recovered_value.equals("top_secret"));
+        System.out.println(recovered_value);
+
+        Object[] enc_key = cryptoImpl.encryptionKeyGen();
+        byte[] alice_ek = (byte[]) enc_key[0];
+        byte[] alice_dk = (byte[]) enc_key[1];
+
+        Object[] sign_key = cryptoImpl.signatureKeyGen();
+        byte[] alice_vk = (byte[]) sign_key[0];
+        byte[] alice_sk = (byte[]) sign_key[1];
+
+        enc_key = cryptoImpl.encryptionKeyGen();
+        byte[] bob_ek = (byte[]) enc_key[0];
+        byte[] bob_dk = (byte[]) enc_key[1];
+
+        sign_key = cryptoImpl.signatureKeyGen();
+        byte[] bob_vk = (byte[]) sign_key[0];
+        byte[] bob_sk = (byte[]) sign_key[1];
+
+
+
+        byte[] ciphertext = cryptoImpl.signThenEncrypt(secret, alice_sk, bob_ek);
+        byte[] plaintext = cryptoImpl.decryptThenVerify(ciphertext, alice_vk, bob_dk);
+        recovered_value = new String(recovered, StandardCharsets.UTF_8);
+        assert(recovered_value.equals("top_secret"));
+        System.out.println(recovered_value);
+    }
+}

--- a/jni/build.gradle
+++ b/jni/build.gradle
@@ -11,7 +11,7 @@ apply plugin: 'java'
 apply plugin: "com.google.protobuf"
 apply plugin: 'idea'
 apply plugin: 'application'
-mainClassName = "src.DerecCryptoBridgeTestMain"
+mainClassName = "org.derecalliance.derec.crypto.DerecCryptoBridgeTestMain"
 
 sourceSets {
   main {
@@ -19,7 +19,7 @@ sourceSets {
         srcDir 'src/proto/bridge'
     }
     java {
-        srcDirs 'src'
+        srcDirs 'src/main/java/org/derecalliance/derec/crypto'
         srcDirs 'build/generated/source/proto/main/java'
     }
   }
@@ -50,7 +50,7 @@ application {
 
 jar { exclude '*.proto' }
 
-group 'src'
+group 'src/main/java'
 version '1.0-SNAPSHOT'
 sourceCompatibility = '11'
 

--- a/jni/build.gradle
+++ b/jni/build.gradle
@@ -12,13 +12,11 @@ apply plugin: "com.google.protobuf"
 apply plugin: 'idea'
 apply plugin: 'application'
 mainClassName = "src.DerecCryptoBridgeTestMain"
-//sourceSets.main.java.srcDirs = ['src']
+
 sourceSets {
   main {
     proto {
-        // In addition to the default 'src/main/proto'
         srcDir 'src/proto/bridge'
-        srcDir 'src/proto/protobufs'
     }
     java {
         srcDirs 'src'
@@ -49,6 +47,8 @@ protobuf {
 application {
     applicationDefaultJvmArgs = ["-Djava.library.path=derec_crypto_bridge_lib/target/debug"]
 }
+
+jar { exclude '*.proto' }
 
 group 'src'
 version '1.0-SNAPSHOT'

--- a/jni/derec_crypto_bridge_lib/src/lib.rs
+++ b/jni/derec_crypto_bridge_lib/src/lib.rs
@@ -52,7 +52,7 @@ use derec_crypto::secure_channel::sign::*;
 // of a native method based on its name.
 
 #[no_mangle]
-pub extern "system" fn Java_src_DerecCryptoImpl_nativeShare<'local>(
+pub extern "system" fn Java_org_derecalliance_derec_crypto_DerecCryptoImpl_nativeShare<'local>(
     env: JNIEnv<'local>,
     _class: JClass,
     in_threshold: jint,
@@ -108,7 +108,7 @@ pub extern "system" fn Java_src_DerecCryptoImpl_nativeShare<'local>(
 
 
 #[no_mangle]
-pub extern "system" fn Java_src_DerecCryptoImpl_nativeRecover<'local>(
+pub extern "system" fn Java_org_derecalliance_derec_crypto_DerecCryptoImpl_nativeRecover<'local>(
     env: JNIEnv<'local>,
     _class: JClass,
     in_proto_msg: JByteArray<'local>,
@@ -146,7 +146,7 @@ pub extern "system" fn Java_src_DerecCryptoImpl_nativeRecover<'local>(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_src_DerecCryptoImpl_nativeEncKeyGen<'local>(
+pub extern "system" fn Java_org_derecalliance_derec_crypto_DerecCryptoImpl_nativeEncKeyGen<'local>(
     env: JNIEnv<'local>,
     _class: JClass,
 ) -> JByteArray<'local> {
@@ -164,7 +164,7 @@ pub extern "system" fn Java_src_DerecCryptoImpl_nativeEncKeyGen<'local>(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_src_DerecCryptoImpl_nativeSignKeyGen<'local>(
+pub extern "system" fn Java_org_derecalliance_derec_crypto_DerecCryptoImpl_nativeSignKeyGen<'local>(
     env: JNIEnv<'local>,
     _class: JClass,
 ) -> JByteArray<'local> {
@@ -194,7 +194,7 @@ pub extern "system" fn Java_src_DerecCryptoImpl_nativeSignKeyGen<'local>(
 // );
 
 #[no_mangle]
-pub extern "system" fn Java_src_DerecCryptoImpl_nativeSignThenEncrypt<'local>(
+pub extern "system" fn Java_org_derecalliance_derec_crypto_DerecCryptoImpl_nativeSignThenEncrypt<'local>(
     env: JNIEnv<'local>,
     _class: JClass,
     in_plaintext: JByteArray<'local>,
@@ -216,7 +216,7 @@ pub extern "system" fn Java_src_DerecCryptoImpl_nativeSignThenEncrypt<'local>(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_src_DerecCryptoImpl_nativeDecryptThenVerify<'local>(
+pub extern "system" fn Java_org_derecalliance_derec_crypto_DerecCryptoImpl_nativeDecryptThenVerify<'local>(
     env: JNIEnv<'local>,
     _class: JClass,
     in_ciphertext: JByteArray<'local>,

--- a/jni/src/main/java/org/derecalliance/derec/crypto/DerecCryptoBridgeTestMain.java
+++ b/jni/src/main/java/org/derecalliance/derec/crypto/DerecCryptoBridgeTestMain.java
@@ -1,10 +1,10 @@
-package src;
+package org.derecalliance.derec.crypto;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-import src.DerecCryptoInterface;
-import src.DerecCryptoImpl;
+import org.derecalliance.derec.crypto.DerecCryptoInterface;
+import org.derecalliance.derec.crypto.DerecCryptoImpl;
 
 public class DerecCryptoBridgeTestMain {
     public static void main(String[] args) {

--- a/jni/src/main/java/org/derecalliance/derec/crypto/DerecCryptoImpl.java
+++ b/jni/src/main/java/org/derecalliance/derec/crypto/DerecCryptoImpl.java
@@ -1,4 +1,4 @@
-package src;
+package org.derecalliance.derec.crypto;
 
 import java.security.SecureRandom;
 import java.util.ArrayList;

--- a/jni/src/main/java/org/derecalliance/derec/crypto/DerecCryptoInterface.java
+++ b/jni/src/main/java/org/derecalliance/derec/crypto/DerecCryptoInterface.java
@@ -1,4 +1,4 @@
-package src;
+package org.derecalliance.derec.crypto;
 
 import java.util.List;
 


### PR DESCRIPTION
- removing unnecessary protobuf complications, and excluding all protobuf definitions from the jar target
- sample mvn project that uses the java interface