### PR TITLE
added publishToMavenLocal task

### DIFF
--- a/jni/build.gradle
+++ b/jni/build.gradle
@@ -11,6 +11,7 @@ apply plugin: 'java'
 apply plugin: "com.google.protobuf"
 apply plugin: 'idea'
 apply plugin: 'application'
+apply plugin: 'maven-publish'
 mainClassName = "org.derecalliance.derec.crypto.DerecCryptoBridgeTestMain"
 
 sourceSets {
@@ -63,4 +64,19 @@ dependencies {
 
     implementation 'com.google.protobuf:protobuf-gradle-plugin:0.9.4'
     testImplementation group: 'junit', name: 'junit', version: '4.12'
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+            groupId = 'src'
+            artifactId = 'derec-crypto-bridge'
+            version = '1.0-SNAPSHOT'
+        }
+    }
+
+    repositories {
+        mavenLocal()
+    }
 }


### PR DESCRIPTION
Added a task to build.gradle that allows the user to publish the built JAR to Maven local repository.

To run this task, run the `gradle clean build publishToMavenLocal` command in the `jni` folder.

Fixes #28 